### PR TITLE
ci: migrate publish workflow to changelog validation, bump to v8.0.0

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -83,7 +83,7 @@ jobs:
           fi
 
       - name: Coverage report
-        uses: davelosert/vitest-coverage-report-action@3c50566c523e04813df28de8f7c48dd97d663f1c # v2.11.2
+        uses: davelosert/vitest-coverage-report-action@02f3c2e641286b7fa308cd3e430783103ce6103b # v2.12.0
         with:
           json-summary-path: coverage/coverage-summary.json
           json-summary-compare-path: ${{ steps.base-coverage.outputs.exists == 'true' && '/tmp/base-coverage/coverage-summary.json' || '' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,63 +23,52 @@ on:
 permissions: {}
 
 jobs:
-  stamp-changelog:
-    name: Stamp changelog
+  check-changelog:
+    name: Check changelog
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      id-token: write
+      contents: read
     steps:
-      - name: Get secrets from Vault
-        id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@f1614b210386ac420af6807a997ac7f6d96e477a # get-vault-secrets/v1.3.1
-        with:
-          vault_instance: ops
-          common_secrets: |
-            GITHUB_APP_ID=plugins-platform-bot-app:app-id
-            GITHUB_APP_PRIVATE_KEY=plugins-platform-bot-app:private-key
-          export_env: false
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
-        with:
-          app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
-          private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.event.inputs.branch }}
-          token: ${{ steps.app-token.outputs.token }}
-      - name: Replace [Unreleased] with version and date
+      - name: Verify CHANGELOG.md files have no [Unreleased] section
         run: |
-          grep -q "## \[Unreleased\]" CHANGELOG.md || { echo "No [Unreleased] heading in CHANGELOG.md \ already stamped?"; exit 1; }
-          VERSION=$(node -p "require('./package.json').version")
-          DATE=$(date -u +%Y-%m-%d)
-          sed -i "s/## \[Unreleased\]/## [$VERSION] - $DATE/" CHANGELOG.md
+          check_changelog() {
+            local file="$1"
+            UNRELEASED_LINE=$(grep -n "^## \[Unreleased\]" "$file" | head -1 | cut -d: -f1)
+            RELEASE_LINE=$(grep -n "^## \[[0-9]" "$file" | head -1 | cut -d: -f1)
+
+            # No [Unreleased] section — nothing to check
+            if [ -z "$UNRELEASED_LINE" ]; then
+              return 0
+            fi
+
+            # [Unreleased] is below the latest release — fine
+            if [ -n "$RELEASE_LINE" ] && [ "$UNRELEASED_LINE" -gt "$RELEASE_LINE" ]; then
+              return 0
+            fi
+
+            VERSION=$(jq -r '.version' package.json)
+            echo "Error: $file contains an [Unreleased] section."
+            echo "A released version is required and must match package.json (${VERSION})."
+            return 1
+          }
+
+          check_changelog CHANGELOG.md || exit 1
           if [ -f src/CHANGELOG.md ]; then
-            grep -q "## \[Unreleased\]" src/CHANGELOG.md || { echo "No [Unreleased] heading in src/CHANGELOG.md \ already stamped?"; exit 1; }
-            sed -i "s/## \[Unreleased\]/## [$VERSION] - $DATE/" src/CHANGELOG.md
+            check_changelog src/CHANGELOG.md || exit 1
           fi
-      - name: Commit changelog stamp
-        env:
-          BRANCH: ${{ github.event.inputs.branch }}
-        run: |
-          git config user.name 'grafana-plugins-platform-bot[bot]'
-          git config user.email '144369747+grafana-plugins-platform-bot[bot]@users.noreply.github.com'
-          git add CHANGELOG.md
-          [ -f src/CHANGELOG.md ] && git add src/CHANGELOG.md
-          git diff --staged --quiet || git commit -m "chore: stamp changelog for release"
-          git push origin HEAD:$BRANCH
 
   cd:
     name: CD
-    needs: stamp-changelog
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v7.3.1
+    needs: check-changelog
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.0
     permissions:
-      contents: write
-      pull-requests: read
-      id-token: write
       attestations: write
+      contents: write
+      id-token: write
+      pull-requests: read
     with:
       branch: ${{ github.event.inputs.branch }}
       environment: ${{ github.event.inputs.environment }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v7.3.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v8.0.0
     permissions:
       contents: read
       pull-requests: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,11 @@ This changelog follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.
 
 - Updated CI/CD workflows.
 - Updated development scripts and tooling.
-- Changelog is now automatically stamped with version and date on release.
 - Removed `pr-files.yml` workflow; GitHub's native Files changed tab supersedes it.
 - Added `.npmrc` with `ignore-scripts=true` to disable lifecycle scripts and mitigate supply-chain attack risk.
+- Migrated publish workflow from auto-stamping changelog to pre-flight changelog validation.
+- Bumped `plugin-ci-workflows` to v8.0.0.
+- Bumped `vitest-coverage-report-action` to v2.12.0.
 
 ## [4.4.0] - 2025-07-12
 

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -12,12 +12,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated to latest plugin build tooling
 - Added cspell configuration
 - Added coverage to CI test script
-- Bumped CI reusable workflow to ci-cd-workflows/v7.3.1
+- Bumped CI reusable workflow to ci-cd-workflows/v8.0.0
 - Added concurrency groups to all workflows to cancel stale runs
 - Added pull-requests: read and attestations: write permissions to CI job
-- Added stamp-changelog job to publish workflow: stamps CHANGELOG.md and src/CHANGELOG.md (if present) on release
+- Migrated publish workflow from auto-stamping changelog to pre-flight changelog validation
 - Bumped actions/checkout to v6, actions/setup-node to v6.4.0 across coverage workflow
-- Bumped davelosert/vitest-coverage-report-action to v2.11.2
+- Bumped davelosert/vitest-coverage-report-action to v2.12.0
 - Bumped actions/create-github-app-token to v3.1.1 in publish workflow
 - Bumped ArtiomTr/jest-coverage-report-action to v2.3.1 in coverage workflow
 - Added continue-on-error on base branch coverage run, base-coverage existence check


### PR DESCRIPTION
The publish workflow used to auto-stamp `CHANGELOG.md` on release — committing a version and date in place of `[Unreleased]`. That required a GitHub App token and write access, which feels like overkill for what is essentially a pre-flight check.

This PR swaps it out for a simple read-only gate: if either `CHANGELOG.md` or `src/CHANGELOG.md` still has an `[Unreleased]` section above the latest versioned release when you trigger a deploy, the workflow fails with a clear message. You stamp the changelog yourself before releasing.

### CI/CD

- Replaced `stamp-changelog` job with `check-changelog` (read-only, no token, no git writes)
- Check covers both `CHANGELOG.md` and `src/CHANGELOG.md` (if present)
- Line-number comparison prevents false positives from `[Unreleased]` appearing in older history
- `cd` job now depends on `check-changelog`
- Bumped `plugin-ci-workflows` to `v8.0.0` in `push.yml`

### Dependencies

- Bumped `vitest-coverage-report-action` to `v2.12.0` in `coverage.yml`

## Test plan

- [ ] Trigger publish on a branch with stamped `CHANGELOG.md` and `src/CHANGELOG.md` — workflow passes
- [ ] Trigger publish on a branch with an `[Unreleased]` section in either file — workflow fails with a clear error
- [ ] Confirm the `cd` job runs after the changelog check passes