### PR TITLE
chore: disable Renovate major-version bump PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a `renovate.json` to prevent Renovate from opening major-version bump PRs. Minor and patch updates continue as normal.

## Why

Major bumps often include breaking changes that need manual work — not safe to auto-merge. This keeps Renovate PRs low-risk and actionable.

## Changes

- `renovate.json` — new file; extends `config:recommended`, disables `major` update type